### PR TITLE
Add "redeliver" alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+- Add alias `gh redeliver` (See [#1](https://github.com/salcode/salcode-gh-cli/issues/1))
+
 ## [1.0.0] - 2021-08-22
 - Initial setup using default GitHub CLI `config.yml` values.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 My configuration for GitHub CLI and notes.
 
+## Aliases
+
+### `gh redeliver <PR URL>`
+
+Based on the PR URL (e.g. `https://github.com/salcode/my-example-repo/pull/23`) find the most recent webhook delivery (for the first webhook defined for the repo (`salcode/my-example-repo`)) where:
+
+- the `action` has a value of `closed`
+- the `event` has a value of `pull_request`
+- the Pull Request ID (`.request.payload.number`) matches the Pull Request Number in the URL
+
+e.g. `gh redeliver https://github.com/salcode/my-example-repo/pull/23`
+
 ## Setup
 
 Clone this repo (e.g. in your home directory)

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ My configuration for GitHub CLI and notes.
 
 ## Aliases
 
-### `gh redeliver <PR URL>`
+### `gh redeliver <webhook payload URL>`
 
-Based on the PR URL (e.g. `https://github.com/salcode/my-example-repo/pull/23`) find the most recent webhook delivery (for the first webhook defined for the repo (`salcode/my-example-repo`)) where:
+Based on the webhook payload URL (e.g. `https://example.com/dev/hook`) resend the most recent webhook delivery to that URL that meets the criteria:
 
 - the `action` has a value of `closed`
 - the `event` has a value of `pull_request`
-- the Pull Request ID (`.request.payload.number`) matches the Pull Request Number in the URL
 
-e.g. `gh redeliver https://github.com/salcode/my-example-repo/pull/23`
+e.g. `gh redeliver https://example.com/dev/hook`
+
+**Note**: Your current branch has no impact on which webhook delivery is resent.
 
 ## Setup
 

--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,7 @@ aliases:
         | .id
       ] | .[0] \"); \
       echo \"DELIVERYID: $DELIVERYID\"; \
+      gh api --method POST /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/$DELIVERYID/attempts;
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -24,6 +24,8 @@ aliases:
       echo $ARG; \
       OWNERREPO=$(echo $ARG | cut -d '/' -f 4-5); \
       echo \"OWNERREPO: $OWNERREPO\"; \
+      PRNUM=$(echo $ARG | cut -d '/' -f 7);
+      echo \"PRNUM: $PRNUM\"; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,8 @@ aliases:
     # e.g. gh redeliver https://github.com/salcode/my-example-repo/pull/23
     redeliver: "!ARG=$1; f() { \
       echo $ARG; \
+      OWNERREPO=$(echo $ARG | cut -d '/' -f 4-5); \
+      echo \"OWNERREPO: $OWNERREPO\"; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -9,5 +9,21 @@ pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
     co: pr checkout
+
+    # gh redeliver <PR URL>
+    #
+    # Find the first webhook defined for a repo,
+    # locate the most recent delivery sent that
+    # "closed" a "pull_request"
+    # with a matching pull request ID
+    # and redeliver that webhook delivery.
+    #
+    # @param $1 A GitHub PR URL (e.g. https://github.com/salcode/my-example-repo/pull/23)
+    #
+    # e.g. gh redeliver https://github.com/salcode/my-example-repo/pull/23
+    redeliver: "!f() { \
+      echo \'stub redeliver\'; \
+    }; f"
+
 # The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 http_unix_socket:

--- a/config.yml
+++ b/config.yml
@@ -32,7 +32,8 @@ aliases:
         | select(.action == \"closed\")
         | select(.event == \"pull_request\")
         | .id' \
-      | xargs -I % -n1 gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/%; \
+      | xargs -I % -n1 gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/% \
+      | jq --slurp \"[.[]]\"; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,7 @@ aliases:
       | xargs -I % -n1 gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/% \
       | jq --slurp \"[.[] \
         | select(.request.payload.number == $PRNUM)
+        | .id
       ]\"; \
       echo \'stub redeliver\'; \
     }; f"

--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,11 @@ aliases:
       ] | .[0] \"); \
       echo \"DELIVERYID: $DELIVERYID\"; \
       gh api --method POST /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/$DELIVERYID/attempts;
-      echo \'stub redeliver\'; \
+      echo; \
+      echo \"Redelivered most recent delivery ($DELIVERYID) for webhook ($WEBHOOKID) on repo ($OWNERREPO) where:\"; \
+      echo \"- action: 'closed'\"; \
+      echo \"- event: 'pull_request'\"; \
+      echo \"- PR ID: $PRNUM\"; \
     }; f"
 
 # The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.

--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,8 @@ aliases:
       echo \"WEBHOOKID: $WEBHOOKID\"; \
       gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.[]
         | select(.action == \"closed\")
-        | select(.event == \"pull_request\")'; \
+        | select(.event == \"pull_request\")
+        | .id'; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -31,7 +31,8 @@ aliases:
       gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.[]
         | select(.action == \"closed\")
         | select(.event == \"pull_request\")
-        | .id'; \
+        | .id' \
+      | xargs -I % -n1 gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/%; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -36,7 +36,7 @@ aliases:
       | jq --slurp \"[.[] \
         | select(.request.payload.number == $PRNUM)
         | .id
-      ]\"; \
+      ] | .[0] \"; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -28,7 +28,9 @@ aliases:
       echo \"PRNUM: $PRNUM\"; \
       WEBHOOKID=$(gh api /repos/$OWNERREPO/hooks --jq '.[0] | .id');
       echo \"WEBHOOKID: $WEBHOOKID\"; \
-      gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.'; \
+      gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.[]
+        | select(.action == \"closed\")
+        | select(.event == \"pull_request\")'; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -28,6 +28,7 @@ aliases:
       echo \"PRNUM: $PRNUM\"; \
       WEBHOOKID=$(gh api /repos/$OWNERREPO/hooks --jq '.[0] | .id');
       echo \"WEBHOOKID: $WEBHOOKID\"; \
+      gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -28,7 +28,7 @@ aliases:
       echo \"PRNUM: $PRNUM\"; \
       WEBHOOKID=$(gh api /repos/$OWNERREPO/hooks --jq '.[0] | .id');
       echo \"WEBHOOKID: $WEBHOOKID\"; \
-      gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries; \
+      gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.'; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -9,37 +9,23 @@ pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
     co: pr checkout
-    # gh redeliver <PR URL>
+    # gh redeliver <webhook payload URL>
     #
-    # Find the first webhook defined for a repo,
-    # locate the most recent delivery sent that
+    # Locate the most recent delivery sent
+    # to the given webhook payload URL that
     # "closed" a "pull_request"
-    # with a matching pull request ID
     # and redeliver that webhook delivery.
     #
-    # @param $1 A GitHub PR URL (e.g. https://github.com/salcode/my-example-repo/pull/23)
+    # @param $1 The webhook Payload URL set in GitHub (e.g. https://example.com/dev/hook)
     #
-    # e.g. gh redeliver https://github.com/salcode/my-example-repo/pull/23
+    # e.g. gh redeliver https://example.com/dev/hook
     redeliver: "!ARG=$1; f() { \
-      OWNERREPO=$(echo $ARG | cut -d '/' -f 4-5); \
-      PRNUM=$(echo $ARG | cut -d '/' -f 7);
-      WEBHOOKID=$(gh api /repos/$OWNERREPO/hooks --jq '.[0] | .id');
-      DELIVERYID=$(gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.[]
-        | select(.action == \"closed\")
-        | select(.event == \"pull_request\")
-        | .id' \
-      | xargs -I % -n1 gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/% \
-      | jq --slurp \"[.[] \
-        | select(.request.payload.number == $PRNUM)
-        | .id
-      ] | .[0] \"); \
-      echo \"DELIVERYID: $DELIVERYID\"; \
-      gh api --method POST /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/$DELIVERYID/attempts;
-      echo; \
-      echo \"Redelivered most recent delivery ($DELIVERYID) for webhook ($WEBHOOKID) on repo ($OWNERREPO) where:\"; \
-      echo \"- action: 'closed'\"; \
-      echo \"- event: 'pull_request'\"; \
-      echo \"- PR ID: $PRNUM\"; \
+      echo \"Redelivering webhook for PR $ARG\"; \
+      WEBHOOK_ID=$(gh api /repos/{owner}/{repo}/hooks | jq --arg webhook_url \"$ARG\" '.[] | select(.config.url==$webhook_url) | .id'); \
+      DELIVERY_ID=$(gh api /repos/{owner}/{repo}/hooks/$WEBHOOK_ID/deliveries --jq 'map(select(.event==\"pull_request\")) | map(select(.action==\"closed\")) | first | .id'); \
+      echo \"$DELIVERY_ID\"; \
+      gh api \"/repos/{owner}/{repo}/hooks/$WEBHOOK_ID/deliveries/$DELIVERY_ID\" --jq '\"Redelivering webhook delivery for PR \\(.request.payload.number) merged into \\(.request.payload.pull_request.base.ref) \\(.request.payload.action)\"'; \
+      gh api --method POST /repos/{owner}/{repo}/hooks/$WEBHOOK_ID/deliveries/$DELIVERY_ID/attempts;
     }; f"
 
 # The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.

--- a/config.yml
+++ b/config.yml
@@ -21,13 +21,9 @@ aliases:
     #
     # e.g. gh redeliver https://github.com/salcode/my-example-repo/pull/23
     redeliver: "!ARG=$1; f() { \
-      echo $ARG; \
       OWNERREPO=$(echo $ARG | cut -d '/' -f 4-5); \
-      echo \"OWNERREPO: $OWNERREPO\"; \
       PRNUM=$(echo $ARG | cut -d '/' -f 7);
-      echo \"PRNUM: $PRNUM\"; \
       WEBHOOKID=$(gh api /repos/$OWNERREPO/hooks --jq '.[0] | .id');
-      echo \"WEBHOOKID: $WEBHOOKID\"; \
       DELIVERYID=$(gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.[]
         | select(.action == \"closed\")
         | select(.event == \"pull_request\")

--- a/config.yml
+++ b/config.yml
@@ -9,7 +9,6 @@ pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
     co: pr checkout
-
     # gh redeliver <PR URL>
     #
     # Find the first webhook defined for a repo,
@@ -21,7 +20,8 @@ aliases:
     # @param $1 A GitHub PR URL (e.g. https://github.com/salcode/my-example-repo/pull/23)
     #
     # e.g. gh redeliver https://github.com/salcode/my-example-repo/pull/23
-    redeliver: "!f() { \
+    redeliver: "!ARG=$1; f() { \
+      echo $ARG; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -28,7 +28,7 @@ aliases:
       echo \"PRNUM: $PRNUM\"; \
       WEBHOOKID=$(gh api /repos/$OWNERREPO/hooks --jq '.[0] | .id');
       echo \"WEBHOOKID: $WEBHOOKID\"; \
-      gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.[]
+      DELIVERYID=$(gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries --jq '.[]
         | select(.action == \"closed\")
         | select(.event == \"pull_request\")
         | .id' \
@@ -36,7 +36,8 @@ aliases:
       | jq --slurp \"[.[] \
         | select(.request.payload.number == $PRNUM)
         | .id
-      ] | .[0] \"; \
+      ] | .[0] \"); \
+      echo \"DELIVERYID: $DELIVERYID\"; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -33,7 +33,9 @@ aliases:
         | select(.event == \"pull_request\")
         | .id' \
       | xargs -I % -n1 gh api /repos/$OWNERREPO/hooks/$WEBHOOKID/deliveries/% \
-      | jq --slurp \"[.[]]\"; \
+      | jq --slurp \"[.[] \
+        | select(.request.payload.number == $PRNUM)
+      ]\"; \
       echo \'stub redeliver\'; \
     }; f"
 

--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,8 @@ aliases:
       echo \"OWNERREPO: $OWNERREPO\"; \
       PRNUM=$(echo $ARG | cut -d '/' -f 7);
       echo \"PRNUM: $PRNUM\"; \
+      WEBHOOKID=$(gh api /repos/$OWNERREPO/hooks --jq '.[0] | .id');
+      echo \"WEBHOOKID: $WEBHOOKID\"; \
       echo \'stub redeliver\'; \
     }; f"
 


### PR DESCRIPTION
With this new alias running a command like

```
gh redeliver https://github.com/salcode/my-example-repo/pull/2
```

will find the most recent webhook delivery where:

- **action** is `closed`
- **event** is `pull_request`
- **Pull Request ID** matches the ID of the pull request in the URL passed as an arg (in this case `2`)

and redeliver that webhook delivery.

Resolves #1