### PR TITLE
Remove extraneous backtick in setup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Add version `1` to `config.yml`
+- Remove extraneous backtick in setup instructions in `README.md` ([#4](https://github.com/salcode/salcode-gh-cli/issues/4))
 
 ## [1.0.0] - 2021-08-22
 - Initial setup using default GitHub CLI `config.yml` values.

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ git clone git@github.com:salcode/salcode-gh-cli.git ~/salcode-gh-cli.git
 Symlink your the `config.yml` in this repo to the GitHub CLI config file location (`~/.config/gh/config.yml`)
 
 ```
-ln -sf ~/salcode-gh-cli/config.yml ~/.config/gh/config.yml`
+ln -sf ~/salcode-gh-cli/config.yml ~/.config/gh/config.yml
 ```


### PR DESCRIPTION
Remove extraneous backtick in setup instructions in README.md

Resolves #4