### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Add version `1` to `config.yml`
 - Remove extraneous backtick in setup instructions in `README.md` ([#4](https://github.com/salcode/salcode-gh-cli/issues/4))
+- Correct location of where to clone repo ([#3](https://github.com/salcode/salcode-gh-cli/issues/3))
 
 ## [1.0.0] - 2021-08-22
 - Initial setup using default GitHub CLI `config.yml` values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Add version `1` to `config.yml`
+
 ## [1.0.0] - 2021-08-22
 - Initial setup using default GitHub CLI `config.yml` values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Add version `1` to `config.yml`
+- Remove extraneous backtick in setup instructions in `README.md` ([#4](https://github.com/salcode/salcode-gh-cli/issues/4))
 
 ## [1.0.0] - 2021-08-22
 - Initial setup using default GitHub CLI `config.yml` values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.1]
 - Add version `1` to `config.yml`
 - Remove extraneous backtick in setup instructions in `README.md` ([#4](https://github.com/salcode/salcode-gh-cli/issues/4))
 - Correct location of where to clone repo ([#3](https://github.com/salcode/salcode-gh-cli/issues/3))

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ git clone git@github.com:salcode/salcode-gh-cli.git ~/salcode-gh-cli.git
 Symlink your the `config.yml` in this repo to the GitHub CLI config file location (`~/.config/gh/config.yml`)
 
 ```
-ln -sf ~/salcode-gh-cli/config.yml ~/.config/gh/config.yml`
+ln -sf ~/salcode-gh-cli/config.yml ~/.config/gh/config.yml
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ My configuration for GitHub CLI and notes.
 Clone this repo (e.g. in your home directory)
 
 ```
-git clone git@github.com:salcode/salcode-gh-cli.git ~/salcode-gh-cli.git
+git clone git@github.com:salcode/salcode-gh-cli.git ~/salcode-gh-cli
 ```
 
 Symlink your the `config.yml` in this repo to the GitHub CLI config file location (`~/.config/gh/config.yml`)

--- a/config.yml
+++ b/config.yml
@@ -11,3 +11,4 @@ aliases:
     co: pr checkout
 # The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 http_unix_socket:
+version: "1"


### PR DESCRIPTION
- Add version `1` to `config.yml`
- Remove extraneous backtick in setup instructions in `README.md` ([#4](https://github.com/salcode/salcode-gh-cli/issues/4))
- Correct location of where to clone repo ([#3](https://github.com/salcode/salcode-gh-cli/issues/3))
